### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,14 +12,14 @@ RgbStrip	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-setTargetColour		KEYWORD2
+setTargetColour	KEYWORD2
 isTransitionsEnabled	KEYWORD2
-setBrightness		KEYWORD2
+setBrightness	KEYWORD2
 setBrightnessIncrement	KEYWORD2
-setLowBrightness 	KEYWORD2
+setLowBrightness	KEYWORD2
 setFullBrightness	KEYWORD2
 setTransitionStep	KEYWORD2
-lightsOff		KEYWORD2
+lightsOff	KEYWORD2
 increaseBrightness	KEYWORD2
 decreaseBrightness	KEYWORD2
 stepTowardsTargetColour	KEYWORD2
@@ -29,9 +29,9 @@ isTargetColourReached	KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################
-DEFAULT_TRANSITION_STEP		LITERAL1
+DEFAULT_TRANSITION_STEP	LITERAL1
 DEFAULT_BRIGHTNESS_INCREMENT	LITERAL1
-DEFAULT_BRIGHTNESS		LITERAL1
-LOW_BRIGHTNESS			LITERAL1
-FULL_BRIGHTNESS			LITERAL1
+DEFAULT_BRIGHTNESS	LITERAL1
+LOW_BRIGHTNESS	LITERAL1
+FULL_BRIGHTNESS	LITERAL1
 


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords